### PR TITLE
Add user-select:none to chat message components

### DIFF
--- a/src/components/Chat/ChatMessage/MediaGroupMessage.jsx
+++ b/src/components/Chat/ChatMessage/MediaGroupMessage.jsx
@@ -76,81 +76,84 @@ function MediaGroupMessage({
             <div className={`flex ${isMe ? "justify-end" : "justify-start"} group`}>
                 {/* Avatar/Spacer for alignment */}
                 {!isMe && (
-                    <div className="ltr:mr-2 rtl:ml-2 self-start">
+                    <div className="ltr:mr-2 rtl:ml-2 self-start select-none" style={{ userSelect: "none" }}>
                         {isFirstInGroup ? (
                             <div
-                                className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center text-xs font-bold text-text cursor-pointer overflow-hidden"
+                                className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center text-xs font-bold text-text cursor-pointer overflow-hidden select-none"
                                 onClick={() => navigate(`/profile/${firstMessage.senderId}`)}
                                 title={firstMessage.senderName}
+                                style={{ userSelect: "none" }}
                             >
                                 {firstMessage.senderPhotoUrl ? (
                                     <img
                                         src={firstMessage.senderPhotoUrl}
                                         alt={firstMessage.senderName || "User"}
-                                        className="w-full h-full object-cover rounded-full"
+                                        className="w-full h-full object-cover rounded-full select-none"
+                                        style={{ userSelect: "none" }}
+                                        draggable={false}
                                     />
                                 ) : (
-                                    <span>
+                                    <span className="select-none" style={{ userSelect: "none" }}>
                                         {firstMessage.senderName?.[0]?.toUpperCase() || 'U'}
                                     </span>
                                 )}
                             </div>
                         ) : (
-                            <div className="w-8 h-8" />
+                            <div className="w-8 h-8 select-none" style={{ userSelect: "none" }} />
                         )}
                     </div>
                 )}
-                <div className={`flex max-w-[85%] flex-col sm:max-w-lg ${isMe ? "items-end" : "items-start"}`}>
-                    {/* Spacer for non-first messages in group */}
-                    {!isMe && !isFirstInGroup && <div className="mr-10"></div>}
-                    <div className="flex flex-col">
-                        {/* Sender name (only for other users and first in group) */}
-                        {!isMe && isFirstInGroup && (
-                            <span
-                                className="text-accent mb-1 max-w-full truncate text-xs font-semibold cursor-pointer hover:underline"
-                                onClick={() => navigate(`/profile/${firstMessage.senderId}`)}
-                                title={firstMessage.senderName}
-                            >
-                                {firstMessage.senderName || "User"}
-                            </span>
-                        )}
-                        <div
-                            className={`${bubbleColor} relative z-0 flex max-w-full flex-col rounded-2xl px-4 py-2.5 break-words shadow-md sm:max-w-lg`}
-                            onContextMenu={(e) =>
-                                onMessageContextMenu && onMessageContextMenu(e, firstMessage)
-                            }
+                <div className={`flex max-w-[85%] flex-col sm:max-w-lg ${isMe ? "items-end" : "items-start"} select-none`} style={{ userSelect: "none" }}>
+                    {/* Sender name (only for other users and first in group) */}
+                    {!isMe && isFirstInGroup && (
+                        <span
+                            className="text-accent mb-1 max-w-full truncate text-xs font-semibold cursor-pointer hover:underline select-none"
                             style={{ userSelect: "none" }}
+                            onClick={() => navigate(`/profile/${firstMessage.senderId}`)}
+                            title={firstMessage.senderName}
                         >
-                            {/* Media Grid */}
+                            {firstMessage.senderName || "User"}
+                        </span>
+                    )}
+                    <div
+                        className={`${bubbleColor} relative z-0 flex max-w-full flex-col rounded-2xl px-4 py-2.5 break-words shadow-md sm:max-w-lg select-none`}
+                        onContextMenu={(e) =>
+                            onMessageContextMenu && onMessageContextMenu(e, firstMessage)
+                        }
+                        style={{ userSelect: "none" }}
+                    >
+                        {/* Media Grid */}
+                        <div className="select-none" style={{ userSelect: "none" }}>
                             {renderMediaGrid(item.messages, openImageSlider)}
-
-                            <div className="mt-1.5 flex items-end justify-between">
-                                {/* Sent time */}
-                                {firstMessage.sentTime && (
-                                    <div
-                                        className={`text-secondary flex items-center gap-1 text-[10px] ${isRTLMessage ? "order-2 ml-2" : "order-1 mr-2"}`}
-                                        dir="ltr"
-                                    >
-                                        <span>{firstMessage.sentTime}</span>
-                                    </div>
-                                )}
-
-                                {/* Message reactions */}
-                                {hasReactions && (
-                                    <div
-                                        className={`flex gap-1 ${isRTLMessage ? "order-1 justify-start" : "order-2 justify-end"}`}
-                                    >
-                                        {Object.entries(reactionCounts).map(([emoji, count]) => (
-                                            <span
-                                                key={emoji}
-                                                className={`rounded-full px-1.5 py-0.5 text-xs ${isMe ? "bg-text/20" : "bg-secondary/10"}`}
-                                            >
-                                                {emoji} {count}
-                                            </span>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
+                        </div>
+                        <div className="mt-1.5 flex items-end justify-between select-none" style={{ userSelect: "none" }}>
+                            {/* Sent time */}
+                            {firstMessage.sentTime && (
+                                <div
+                                    className={`text-secondary flex items-center gap-1 text-[10px] ${isRTLMessage ? "order-2 ml-2" : "order-1 mr-2"} select-none`}
+                                    dir="ltr"
+                                    style={{ userSelect: "none" }}
+                                >
+                                    <span className="select-none" style={{ userSelect: "none" }}>{firstMessage.sentTime}</span>
+                                </div>
+                            )}
+                            {/* Message reactions */}
+                            {hasReactions && (
+                                <div
+                                    className={`flex gap-1 ${isRTLMessage ? "order-1 justify-start" : "order-2 justify-end"} select-none`}
+                                    style={{ userSelect: "none" }}
+                                >
+                                    {Object.entries(reactionCounts).map(([emoji, count]) => (
+                                        <span
+                                            key={emoji}
+                                            className={`rounded-full px-1.5 py-0.5 text-xs ${isMe ? "bg-text/20" : "bg-secondary/10"} select-none`}
+                                            style={{ userSelect: "none" }}
+                                        >
+                                            {emoji} {count}
+                                        </span>
+                                    ))}
+                                </div>
+                            )}
                         </div>
                     </div>
                 </div>

--- a/src/components/Chat/ChatMessage/SingleMessage.jsx
+++ b/src/components/Chat/ChatMessage/SingleMessage.jsx
@@ -115,40 +115,47 @@ function SingleMessage({
                     <div className="flex">
                         {/* Profile picture (only for other users and first in group) */}
                         {!isMe && (
-                            <div className="ltr:mr-2 rtl:ml-2 self-start">
+                            <div className="ltr:mr-2 rtl:ml-2 self-start select-none">
                                 {isFirstInGroup ? (
                                     <div
-                                        className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center text-xs font-bold text-text cursor-pointer overflow-hidden"
+                                        className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center text-xs font-bold text-text cursor-pointer overflow-hidden select-none"
                                         onClick={() => navigate(`/profile/${msg.senderId}`)}
                                         title={msg.senderName}
+                                        style={{ userSelect: "none" }}
                                     >
                                         {msg.senderPhotoUrl ? (
                                             <img
                                                 src={msg.senderPhotoUrl}
                                                 alt={msg.senderName || "User"}
-                                                className="w-full h-full object-cover rounded-full"
+                                                className="w-full h-full object-cover rounded-full select-none"
+                                                style={{ userSelect: "none" }}
+                                                draggable={false}
                                             />
                                         ) : (
-                                            <span>
+                                            <span className="select-none" style={{ userSelect: "none" }}>
                                                 {msg.senderName?.[0]?.toUpperCase() || 'U'}
                                             </span>
                                         )}
                                     </div>
                                 ) : (
                                     // Spacer for alignment
-                                    <div className="w-8 h-8" />
+                                    <div className="w-8 h-8 select-none" style={{ userSelect: "none" }} />
                                 )}
                             </div>
                         )}
-                        <div className="flex flex-col">
+                        <div className="flex flex-col select-none" style={{ userSelect: "none" }}>
                             {/* Sender name (only for other users and first in group) */}
                             {!isMe && isFirstInGroup && (
-                                <span className="text-xs font-semibold mb-1 text-accent truncate max-w-full cursor-pointer" onClick={() => navigate(`/profile/${msg.senderId}`)}>
+                                <span
+                                    className="text-xs font-semibold mb-1 text-accent truncate max-w-full cursor-pointer select-none"
+                                    style={{ userSelect: "none" }}
+                                    onClick={() => navigate(`/profile/${msg.senderId}`)}
+                                >
                                     {msg.senderName || 'User'}
                                 </span>
                             )}
                             <div
-                                className={`${bubbleColor} ${radius} shadow-md px-4 py-2.5 flex flex-col relative z-0 max-w-full sm:max-w-lg break-words`}
+                                className={`${bubbleColor} ${radius} shadow-md px-4 py-2.5 flex flex-col relative z-0 max-w-full sm:max-w-lg break-words select-none`}
                                 onContextMenu={e => onMessageContextMenu && onMessageContextMenu(e, msg)}
                                 onTouchStart={handleTouchStart}
                                 onTouchEnd={handleTouchEnd}
@@ -158,39 +165,49 @@ function SingleMessage({
                             >
                                 {/* Message content */}
                                 {msg.messageType === 'audio' ? (
-                                    <VoiceMessagePlayer
-                                        audioData={msg.audioUrl}
-                                        isMe={isMe}
-                                        duration={msg.duration}
-                                    />
+                                    <div className="select-none" style={{ userSelect: "none" }}>
+                                        <VoiceMessagePlayer
+                                            audioData={msg.audioUrl}
+                                            isMe={isMe}
+                                            duration={msg.duration}
+                                        />
+                                    </div>
                                 ) : msg.messageType === 'image' ? (
-                                    <div className="flex flex-col">
+                                    <div className="flex flex-col select-none" style={{ userSelect: "none" }}>
                                         <img
                                             src={msg.imageUrl}
                                             alt="Shared image"
-                                            className="max-w-full max-h-80 rounded-lg object-cover cursor-pointer hover:opacity-90 transition-opacity"
+                                            className="max-w-full max-h-80 rounded-lg object-cover cursor-pointer hover:opacity-90 transition-opacity select-none"
+                                            style={{ userSelect: "none" }}
                                             onClick={() => openImageSlider([msg], 0)}
+                                            draggable={false}
                                         />
                                         {msg.fileName && (
-                                            <span className="text-xs mt-1 opacity-75">{msg.fileName}</span>
+                                            <span className="text-xs mt-1 opacity-75 select-none" style={{ userSelect: "none" }}>
+                                                {msg.fileName}
+                                            </span>
                                         )}
                                     </div>
                                 ) : msg.messageType === 'video' ? (
-                                    <div className="flex flex-col">
+                                    <div className="flex flex-col select-none" style={{ userSelect: "none" }}>
                                         <video
                                             src={msg.videoUrl}
                                             controls
-                                            className="max-w-full max-h-80 rounded-lg"
+                                            className="max-w-full max-h-80 rounded-lg select-none"
+                                            style={{ userSelect: "none" }}
                                             preload="metadata"
+                                            draggable={false}
                                         >
                                             Your browser does not support the video tag.
                                         </video>
                                         {msg.fileName && (
-                                            <span className="text-xs mt-1 opacity-75">{msg.fileName}</span>
+                                            <span className="text-xs mt-1 opacity-75 select-none" style={{ userSelect: "none" }}>
+                                                {msg.fileName}
+                                            </span>
                                         )}
                                     </div>
                                 ) : (
-                                    <span className={`text-sm break-word text-text}`}>
+                                    <span className={`text-sm break-word text-text select-none`} style={{ userSelect: "none" }}>
                                         {msg.text}
                                     </span>
                                 )}


### PR DESCRIPTION
Applied 'user-select: none' and 'select-none' classes to various elements in MediaGroupMessage and SingleMessage components to prevent unwanted text/image selection and improve UI consistency. Also set draggable={false} for images and videos to further restrict user interaction.